### PR TITLE
Cargo.toml: Update embedded_graphic dependency to 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ keywords = ["embedded", "graphics", "framebuffer"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-embedded-graphics = "0.7.1"
+embedded-graphics = "0.8.1"
 framebuffer = "0.3.0"


### PR DESCRIPTION
This updates the dependency to embedded_graphics to the recent version 0.8.1.
When using this crate with a recent version of embedded_graphics does not work otherwise. The DrawTarget trait is incompatible.